### PR TITLE
Use ed25519 ssh key as default ssh identity key file instead of id_ecdsa key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CheckInterval: 600 (seconds, optional, default = 600)
 SSHConfig:
   HostName: your_ssh_server_hostname (required)
   User: your_ssh_username (required)
-  IdentityFile: path_to_your_ssh_identity_key_file (optional, default = $HOME/.ssh/id_ecdsa, $HOME/.ssh/id_rsa)
+  IdentityFile: path_to_your_ssh_identity_key_file (optional, default = $HOME/.ssh/id_ed25519, $HOME/.ssh/id_rsa)
   Port: your_ssh_server_port (optional, default = 22)
   KeepaliveInterval: 3 (seconds, optional, default = 3)
   Timeout: 5 (seconds, optional, default = 5)

--- a/configs.go
+++ b/configs.go
@@ -30,7 +30,7 @@ func (c *SSHConfig) getKeyPath() string {
 
 	sshDir := fmt.Sprintf("%s/.ssh", os.Getenv("HOME"))
 
-	ecdsaPath := fmt.Sprintf("%s/id_ecdsa", sshDir)
+	ecdsaPath := fmt.Sprintf("%s/id_ed25519", sshDir)
 	if _, err := os.Stat(ecdsaPath); err == nil {
 		return ecdsaPath
 	}


### PR DESCRIPTION
## Summary
In golang latest crypt package, Golang only handle ed25519 and rsa keys currently.
So I think that kushi should use id_ed25519 key file as default ssh identity key file instead of id_ecdsa key.

see : https://github.com/golang/crypto/blob/master/ssh/keys.go#L1010L1077