### PR TITLE
Add more details to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ BindingConfigsURL: file:///path/to/your_binding_list.yaml (edit)
 % kushi --stdout
 ```
 
+#### Options
+
+```
+GLOBAL OPTIONS:
+   --config value, -c value  Config path
+   --pass, -p                Be usable identity file with passphrase
+   --stdout                  Output logs to STDOUT
+   --help, -h                show help
+   --version, -v             print the version
+```
+
+#### Example with options
+
+```
+# You have two or more config files and identity file has passphrase.
+kushi --config ~/.config/kushi/alternative-server-config.yml --pass 
+```
+
+
+
 ### 4. (Optional) Run as daemon
 
 ```

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:        "pass, p",
-			Usage:       "passphrase",
+			Usage:       "Be usable identity file with passphrase",
 			Destination: &passphraseFlag,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
Kushi has `--pass` option for using identity file including passphrase but undocumented so I wrote about it.